### PR TITLE
Diaspora MCP: Containerization and GitHub Action Deployment

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,81 @@
+name: Deploy Diaspora MCP
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      AWS_REGION: us-east-1
+      SERVICE: science-mcps-diaspora
+      CONTAINER: fastmcp
+      CONTAINER_PATH: mcps/diaspora/Dockerfile
+      PORT: 8000
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::423623835312:role/github-action-role
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Delete old Docker images
+        run: |
+          output=$(aws lightsail get-container-images --region $AWS_REGION --service-name $SERVICE --no-paginate --output text)
+          container_names=($(echo "$output" | awk '{print $NF}'))
+          for name in "${container_names[@]:1}"; do
+            echo "IMAGE TO DELETE $name"
+            aws lightsail delete-container-image --region $AWS_REGION --service-name $SERVICE --image "$name" || true
+          done
+
+      - name: Build Docker image
+        run: |
+          docker build --platform=linux/amd64 -t $SERVICE -f $CONTAINER_PATH .
+
+      - name: Install Lightsail plugin prerequisites
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y curl
+          curl -fsSL "https://s3.us-west-2.amazonaws.com/lightsailctl/latest/linux-amd64/lightsailctl" \
+            | sudo tee /usr/local/bin/lightsailctl >/dev/null
+          sudo chmod +x /usr/local/bin/lightsailctl
+
+      - name: Ensure Lightsail service exists
+        run: |
+          aws lightsail create-container-service \
+            --region $AWS_REGION \
+            --service-name $SERVICE \
+            --power micro \
+            --scale 1 \
+            || true
+
+      - name: Push image to Lightsail
+        run: |
+            aws lightsail push-container-image \
+            --region $AWS_REGION \
+            --service-name $SERVICE \
+            --label $CONTAINER \
+            --image $SERVICE  
+
+      - name: Deploy to Lightsail
+        run: |
+            # Lightsail expects the image reference with leading colon:
+            IMAGE_NAME=":${SERVICE}.${CONTAINER}.latest"
+
+            aws lightsail create-container-service-deployment \
+            --region $AWS_REGION \
+            --service-name $SERVICE \
+            --containers \
+                "{\"${CONTAINER}\": {\"image\": \"${IMAGE_NAME}\", \"ports\": {\"${PORT}\": \"HTTP\"}}}" \
+            --public-endpoint \
+                "{\"containerName\": \"${CONTAINER}\", \"containerPort\": ${PORT}}"

--- a/mcps/diaspora/Dockerfile
+++ b/mcps/diaspora/Dockerfile
@@ -1,0 +1,13 @@
+FROM continuumio/miniconda3
+
+EXPOSE 8000/tcp
+
+WORKDIR /science-mcps/mcps/diaspora
+
+COPY mcps/diaspora/diaspora_server.py diaspora_server.py
+COPY mcps/diaspora/requirements.txt requirements.txt
+
+RUN conda create -y -n science-mcps python=3.11 && \
+    conda run -n science-mcps pip install -r requirements.txt
+
+ENTRYPOINT ["conda", "run", "--no-capture-output", "-n", "science-mcps", "python", "diaspora_server.py"]

--- a/mcps/diaspora/diaspora_server.py
+++ b/mcps/diaspora/diaspora_server.py
@@ -234,4 +234,4 @@ def consume_latest_event(
 # Entrypoint
 
 if __name__ == "__main__":
-    mcp.run()
+    mcp.run(transport="streamable-http", host="0.0.0.0", port=8000, path="/mcps/diaspora")


### PR DESCRIPTION
**Description:**
This pull request introduces two major enhancements to the Diaspora MCP server:

1. **Docker Containerization**

   * Adds a `Dockerfile` at `mcps/diaspora/Dockerfile` based on `continuumio/miniconda3`.
   * Creates the `science-mcps` conda environment (Python 3.11) and installs dependencies from `requirements.txt`.
   * Exposes port `8000` and configures the container’s entrypoint to launch `diaspora_server.py` inside the conda environment.

2. **Automated Deployment via GitHub Actions**

   * Adds `.github/workflows/deploy.yaml`, which:

     * Builds the Docker image for `linux/amd64`.
     * Cleans up any old Lightsail container images.
     * Ensures the target Amazon Lightsail container service exists.
     * Installs the `lightsailctl` plugin prerequisites (curl, binary) to enable `push-container-image`.
     * Pushes the newly built image to Lightsail and deploys it, using the canonical Lightsail image name format (`:service.container.latest`).
   * Leverages GitHub OIDC to assume an IAM role (`role-to-assume`) for secure AWS credentials.
   * Is triggered on pushes to `main` and via manual dispatch.

**Testing:**

1. **Local build:**

   ```bash
   docker build --platform=linux/amd64 -t science-mcps-diaspora .
   ```
2. **Lightsail push (requires AWS CLI v2 + lightsailctl):**

   ```bash
   aws lightsail push-container-image \
     --region us-east-1 \
     --service-name science-mcps-diaspora \
     --label fastmcp \
     --image science-mcps-diaspora
   ```

3. **Lightsail deployment:**

   ```bash
   image_name=":science-mcps-diaspora.fastmcp.latest"
  
   aws lightsail create-container-service-deployment \
    --region us-east-1 \
    --service-name science-mcps-diaspora \
    --containers '{"fastmcp": {"image": "'"$image_name"'", "ports": {"8000": "HTTP"}}}' \
    --public-endpoint '{"containerName": "fastmcp", "containerPort": 8000}'
   ```

4. **Verify deployment** by hitting `http://<our-lightsail-endpoint>:8000/mcps/diaspora`.

**Notes:**

* I'll need to configure the AWS IAM role to authenticate with repos in Globus Labs. Here's the current trust policy:
    ```json
    {
        "Version": "2012-10-17",
        "Statement": [
            {
                "Effect": "Allow",
                "Principal": {
                    "Federated": "arn:aws:iam::423623835312:oidc-provider/token.actions.githubusercontent.com"
                },
                "Action": "sts:AssumeRoleWithWebIdentity",
                "Condition": {
                    "StringEquals": {
                        "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
                        "token.actions.githubusercontent.com:sub": "repo:haochenpan/Globus-MCP-Servers:ref:refs/heads/main"
                    }
                }
            }
        ]
    }
    ```
* I'll extend this YAML to build Docker images for other MCPs in this repo after refactoring other MCPs to fastmcp.

Please review and let me know if any adjustments are needed!