### PR TITLE
Globus and Compute Endpoint MCPs: FastMCP and Containerization

### DIFF
--- a/mcps/compute-facilities/Dockerfile
+++ b/mcps/compute-facilities/Dockerfile
@@ -1,0 +1,17 @@
+FROM continuumio/miniconda3
+
+EXPOSE 8000/tcp
+
+WORKDIR /science-mcps/mcps/compute-facilities
+
+COPY mcps/compute-facilities/alcf_server.py alcf_server.py
+COPY mcps/compute-facilities/nersc_server.py nersc_server.py
+COPY mcps/compute-facilities/requirements.txt requirements.txt
+
+RUN conda create -y -n science-mcps python=3.11 && \
+    conda run -n science-mcps pip install -r requirements.txt
+
+COPY mcps/compute-facilities/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["entrypoint.sh"]

--- a/mcps/compute-facilities/alcf_server.py
+++ b/mcps/compute-facilities/alcf_server.py
@@ -1,363 +1,277 @@
 #!/usr/bin/env python3
 """
-MCP Server for ALCF System Status Monitoring
-Monitors Polaris cluster status by checking job activity.
+ALCF Polaris MCP Server
+
+This MCP server provides tools and resources to monitor ALCF Polaris cluster status and job activity.
 """
 
-import asyncio
 import json
 import logging
-from typing import Any, Dict, List, Optional
-import aiohttp
 from datetime import datetime
 
-# MCP SDK imports
-from mcp.server import NotificationOptions, Server
-from mcp.server.models import InitializationOptions
-from mcp.server.stdio import stdio_server
-from mcp.types import (
-    Resource,
-    Tool,
-    TextContent,
-    ImageContent,
-    EmbeddedResource,
-    LoggingLevel
-)
+import aiohttp
+from fastmcp import Context, FastMCP
 
-# Configure logging
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger("alcf-status-mcp")
+logger = logging.getLogger(__name__)
+mcp = FastMCP("ALCF Polaris Status Bridge")
 
-class ALCFStatusMCP:
-    def __init__(self):
-        self.server = Server("alcf-status-mcp")
-        self.alcf_status_url = "https://status.alcf.anl.gov/polaris/activity.json"
-        self.session: Optional[aiohttp.ClientSession] = None
-        
-        # Register handlers
-        self._register_handlers()
-    
-    def _register_handlers(self):
-        """Register MCP handlers"""
-        
-        @self.server.list_resources()
-        async def handle_list_resources() -> List[Resource]:
-            """List available resources"""
-            return [
-                Resource(
-                    uri="alcf://polaris/status",
-                    name="Polaris System Status",
-                    description="Current system status of ALCF Polaris cluster",
-                    mimeType="application/json"
-                ),
-                Resource(
-                    uri="alcf://polaris/jobs",
-                    name="Polaris Job Activity",
-                    description="Current job activity on ALCF Polaris cluster",
-                    mimeType="application/json"
+ALCF_STATUS_URL = "https://status.alcf.anl.gov/polaris/activity.json"
+
+
+async def _get_http_session() -> aiohttp.ClientSession:
+    if not hasattr(_get_http_session, "session"):
+        _get_http_session.session = aiohttp.ClientSession()
+    return _get_http_session.session
+
+
+async def _fetch_activity_data() -> dict:
+    session = await _get_http_session()
+    try:
+        async with session.get(ALCF_STATUS_URL) as resp:
+            if resp.status == 200:
+                return await resp.json()
+            else:
+                raise Exception(f"HTTP {resp.status}: {await resp.text()}")
+    except Exception as e:
+        logger.error(f"Error fetching ALCF activity: {e}")
+        raise
+
+
+async def _get_system_status() -> dict:
+    """Summarize system status."""
+    data = await _fetch_activity_data()
+    running = data.get("running", [])
+    starting = data.get("starting", [])
+    queued = data.get("queued", [])
+    total = len(running) + len(starting) + len(queued)
+    return {
+        "timestamp": datetime.utcnow().isoformat(),
+        "system_operational": bool(running),
+        "total_jobs": total,
+        "running_jobs": len(running),
+        "starting_jobs": len(starting),
+        "queued_jobs": len(queued),
+    }
+
+
+async def _get_job_activity() -> dict:
+    """Return raw job activity data."""
+    return await _fetch_activity_data()
+
+
+async def _check_alcf_status(detailed: bool = False) -> str:
+    """Return a formatted status report."""
+    try:
+        data = await _fetch_activity_data()
+        running_jobs = data.get("running", [])
+        starting_jobs = data.get("starting", [])
+        queued_jobs = data.get("queued", [])
+
+        total_jobs = len(running_jobs) + len(queued_jobs) + len(starting_jobs)
+
+        if total_jobs == 0:
+            return "⚠️  ALCF Polaris Status: No job data available"
+
+        # Generate status report
+        status_lines = [
+            f"🖥️  ALCF Polaris System Status - {datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S UTC')}",
+            "=" * 60,
+        ]
+
+        if running_jobs:
+            status_lines.append(
+                f"✅ System Status: OPERATIONAL ({len(running_jobs)} jobs running)"
+            )
+        else:
+            status_lines.append("❌ System Status: NO RUNNING JOBS")
+
+        status_lines.append(f"📊 Total Jobs: {total_jobs}")
+
+        # Job state breakdown
+        status_lines.append("\n📋 Job State Summary:")
+        status_lines.append(f"   🟢 RUNNING: {len(running_jobs)}")
+        status_lines.append(f"   🔵 QUEUED: {len(queued_jobs)}")
+        status_lines.append(f"   ⚪ STARTING: {len(starting_jobs)}")
+
+        if detailed and running_jobs:
+            status_lines.append(f"\n🏃 Running Jobs Details:")
+            for i, job in enumerate(running_jobs[:10]):  # Limit to first 10
+                job_id = job.get("jobid", "unknown")
+                project = job.get("project", "unknown")
+                nodes = job.get("location", "unknown")
+                queue = job.get("queue", "unknown")
+                status_lines.append(
+                    f"   {i + 1}. Job {job_id} | Project: {project} | Queue: {queue} | Nodes: {nodes}"
                 )
-            ]
-        
-        @self.server.read_resource()
-        async def handle_read_resource(uri: str) -> str:
-            """Read resource content"""
-            if uri == "alcf://polaris/status":
-                status = await self._get_system_status()
-                return json.dumps(status, indent=2)
-            elif uri == "alcf://polaris/jobs":
-                jobs = await self._get_job_activity()
-                return json.dumps(jobs, indent=2)
-            else:
-                raise ValueError(f"Unknown resource: {uri}")
-        
-        @self.server.list_tools()
-        async def handle_list_tools() -> List[Tool]:
-            """List available tools"""
-            return [
-                Tool(
-                    name="check_alcf_status",
-                    description="Check the current system status of ALCF Polaris cluster",
-                    inputSchema={
-                        "type": "object",
-                        "properties": {
-                            "detailed": {
-                                "type": "boolean",
-                                "description": "Whether to return detailed job information",
-                                "default": False
-                            }
-                        }
-                    }
-                ),
-                Tool(
-                    name="get_running_jobs",
-                    description="Get information about currently running jobs on Polaris",
-                    inputSchema={
-                        "type": "object",
-                        "properties": {
-                            "limit": {
-                                "type": "integer",
-                                "description": "Maximum number of running jobs to return",
-                                "default": 10
-                            }
-                        }
-                    }
-                ),
-                Tool(
-                    name="system_health_summary",
-                    description="Get a summary of system health based on job activity",
-                    inputSchema={
-                        "type": "object",
-                        "properties": {}
-                    }
-                )
-            ]
-        
-        @self.server.call_tool()
-        async def handle_call_tool(name: str, arguments: Dict[str, Any]) -> List[TextContent]:
-            """Handle tool calls"""
-            if name == "check_alcf_status":
-                detailed = arguments.get("detailed", False)
-                result = await self._check_alcf_status(detailed)
-                return [TextContent(type="text", text=result)]
-            
-            elif name == "get_running_jobs":
-                limit = arguments.get("limit", 10)
-                result = await self._get_running_jobs(limit)
-                return [TextContent(type="text", text=result)]
-            
-            elif name == "system_health_summary":
-                result = await self._get_system_health_summary()
-                return [TextContent(type="text", text=result)]
-            
-            else:
-                raise ValueError(f"Unknown tool: {name}")
-    
-    async def _get_session(self) -> aiohttp.ClientSession:
-        """Get or create HTTP session"""
-        if self.session is None:
-            self.session = aiohttp.ClientSession()
-        return self.session
-    
-    async def _fetch_activity_data(self) -> Dict[str, Any]:
-        """Fetch activity data from ALCF status endpoint"""
-        session = await self._get_session()
-        
-        try:
-            async with session.get(self.alcf_status_url) as response:
-                if response.status == 200:
-                    data = await response.json()
-                    return data
-                else:
-                    raise Exception(f"HTTP {response.status}: {await response.text()}")
-        except Exception as e:
-            logger.error(f"Error fetching ALCF status: {e}")
-            raise
-    
-    async def _get_system_status(self) -> Dict[str, Any]:
-        """Get system status information"""
-        try:
-            data = await self._fetch_activity_data()
-            
-            # Analyze the data to determine system status
-            running_jobs = data.get("running", [])
-            starting_jobs = data.get("starting", [])
-            queued_jobs = data.get("queued", [])
-            total_jobs = len(running_jobs) + len(queued_jobs) + len(starting_jobs)
 
-            status = {
-                "timestamp": datetime.now().isoformat(),
-                "system_operational": len(running_jobs) > 0,
-                "total_jobs": total_jobs,
-                "running_jobs": len(running_jobs),
-                "starting_jobs": len(starting_jobs),
-                "queued_jobs": len(queued_jobs),
-                "status_summary": "Operational" if len(running_jobs) > 0 else "No running jobs detected"
-            }
-            
-            return status
-            
-        except Exception as e:
-            return {
-                "timestamp": datetime.now().isoformat(),
-                "system_operational": False,
-                "error": str(e),
-                "status_summary": "Error retrieving status"
-            }
-    
-    async def _get_job_activity(self) -> Dict[str, Any]:
-        """Get detailed job activity"""
-        try:
-            data = await self._fetch_activity_data()
-            return data
-        except Exception as e:
-            return {"error": str(e)}
-    
-    async def _check_alcf_status(self, detailed: bool = False) -> str:
-        """Check ALCF system status"""
-        try:
-            data = await self._fetch_activity_data()
-            running_jobs = data.get("running", [])
-            starting_jobs = data.get("starting", [])
-            queued_jobs = data.get("queued", [])
-            
-            total_jobs = len(running_jobs) + len(queued_jobs) + len(starting_jobs)
-            
-            if total_jobs == 0:
-                return "⚠️  ALCF Polaris Status: No job data available"
-            
-            # Generate status report
-            status_lines = [
-                f"🖥️  ALCF Polaris System Status - {datetime.now().strftime('%Y-%m-%d %H:%M:%S UTC')}",
-                "=" * 60
-            ]
-            
-            if running_jobs:
-                status_lines.append(f"✅ System Status: OPERATIONAL ({len(running_jobs)} jobs running)")
-            else:
-                status_lines.append("❌ System Status: NO RUNNING JOBS")
-            
-            status_lines.append(f"📊 Total Jobs: {total_jobs}")
-            
-            # Job state breakdown
-            status_lines.append("\n📋 Job State Summary:")
-            status_lines.append(f"   🟢 RUNNING: {len(running_jobs)}")
-            status_lines.append(f"   🔵 QUEUED: {len(queued_jobs)}")
-            status_lines.append(f"   ⚪ STARTING: {len(starting_jobs)}")
-            
-            if detailed and running_jobs:
-                status_lines.append(f"\n🏃 Running Jobs Details:")
-                for i, job in enumerate(running_jobs[:10]):  # Limit to first 10
-                    job_id = job.get("jobid", "unknown")
-                    project = job.get("project", "unknown")
-                    nodes = job.get("location", "unknown")
-                    queue = job.get("queue", "unknown")
-                    status_lines.append(f"   {i+1}. Job {job_id} | Project: {project} | Queue: {queue} | Nodes: {nodes}")
-                
-                if len(running_jobs) > 10:
-                    status_lines.append(f"   ... and {len(running_jobs) - 10} more")
-            
-            return "\n".join(status_lines)
-            
-        except Exception as e:
-            return f"❌ Error checking ALCF status: {str(e)}"
-    
-    async def _get_running_jobs(self, limit: int = 10) -> str:
-        """Get information about running jobs"""
-        try:
-            data = await self._fetch_activity_data()
-            running_jobs = data.get("running", [])
-            
-            if not running_jobs:
-                return "📋 No running jobs found on ALCF Polaris"
-            
-            result_lines = [
-                f"🏃 Running Jobs on ALCF Polaris ({len(running_jobs)} total)",
-                "=" * 50
-            ]
-            
-            for i, job in enumerate(running_jobs[:limit]):
-                job_id = job.get("jobid", "N/A")
-                project = job.get("project", "N/A")
-                nodes = job.get("location", "N/A")
-                queue = job.get("queue", "N/A")
-                start_time = job.get("starttime", "N/A")
-                
-                result_lines.append(f"\n🔹 Job #{i+1}")
-                result_lines.append(f"   Job ID: {job_id}")
-                result_lines.append(f"   Project: {project}")
-                result_lines.append(f"   Nodes: {nodes}")
-                result_lines.append(f"   Queue: {queue}")
-                result_lines.append(f"   Start Time: {start_time}")
-            
-            if len(running_jobs) > limit:
-                result_lines.append(f"\n... and {len(running_jobs) - limit} more running jobs")
-            
-            return "\n".join(result_lines)
-            
-        except Exception as e:
-            return f"❌ Error retrieving running jobs: {str(e)}"
-    
-    async def _get_system_health_summary(self) -> str:
-        """Get system health summary"""
-        try:
-            data = await self._fetch_activity_data()
-            running_jobs = data.get("running", [])
-            starting_jobs = data.get("starting", [])
-            queued_jobs = data.get("queued", [])
-            
-            total_jobs = len(running_jobs) + len(queued_jobs) + len(starting_jobs)
-            
-            if not jobs:
-                return "⚠️  System Health: Unable to determine - No job data available"
-            
-            # Calculate health metrics
-            
-            # Determine health status
-            if running_jobs > 0:
-                health_status = "HEALTHY"
-                emoji = "💚"
-            elif queued_jobs > 0:
-                health_status = "IDLE"
-                emoji = "💛"
-            else:
-                health_status = "INACTIVE"
-                emoji = "❤️"
-            
-            summary_lines = [
-                f"{emoji} ALCF Polaris System Health Summary",
-                "=" * 40,
-                f"Overall Status: {health_status}",
-                f"Timestamp: {datetime.now().strftime('%Y-%m-%d %H:%M:%S UTC')}",
-                "",
-                f"📊 Job Statistics:",
-                f"   • Total Jobs: {total_jobs}",
-                f"   • Running: {running_jobs}",
-                f"   • Queued: {queued_jobs}",
-                "",
-                f"🎯 Jobs running: {(running_jobs / max(total_jobs, 1)) * 100:.1f}%"
-            ]
-            
-            # Add recommendations
-            if running_jobs == 0 and queued_jobs > 0:
-                summary_lines.append("\n💡 Note: Jobs are queued but none are running. System may be in maintenance or experiencing issues.")
-            elif running_jobs == 0 and queued_jobs == 0:
-                summary_lines.append("\n💡 Note: No active job activity detected. System may be offline or in maintenance.")
-            
-            return "\n".join(summary_lines)
-            
-        except Exception as e:
-            return f"❌ Error generating health summary: {str(e)}"
-    
-    async def cleanup(self):
-        """Cleanup resources"""
-        if self.session:
-            await self.session.close()
-    
-    async def run(self):
-        """Run the MCP server"""
-        try:
-            async with stdio_server() as (read_stream, write_stream):
-                await self.server.run(
-                    read_stream,
-                    write_stream,
-                    InitializationOptions(
-                        server_name="alcf-status-mcp",
-                        server_version="1.0.0",
-                        capabilities=self.server.get_capabilities(
-                            notification_options=NotificationOptions(),
-                            experimental_capabilities={},
-                            # notification=True,
-                            # experimental={}
-                        )
-                    )
-                )
-        finally:
-            await self.cleanup()
+            if len(running_jobs) > 10:
+                status_lines.append(f"   ... and {len(running_jobs) - 10} more")
 
-async def main():
-    """Main entry point"""
-    mcp = ALCFStatusMCP()
-    await mcp.run()
+        return "\n".join(status_lines)
+
+    except Exception as e:
+        return f"❌ Error checking ALCF status: {str(e)}"
+
+
+async def _get_running_jobs(limit: int = 10) -> str:
+    """Return a formatted list of running jobs."""
+    try:
+        data = await _fetch_activity_data()
+        running_jobs = data.get("running", [])
+
+        if not running_jobs:
+            return "📋 No running jobs found on ALCF Polaris"
+
+        result_lines = [
+            f"🏃 Running Jobs on ALCF Polaris ({len(running_jobs)} total)",
+            "=" * 50,
+        ]
+
+        for i, job in enumerate(running_jobs[:limit]):
+            job_id = job.get("jobid", "N/A")
+            project = job.get("project", "N/A")
+            nodes = job.get("location", "N/A")
+            queue = job.get("queue", "N/A")
+            start_time = job.get("starttime", "N/A")
+
+            result_lines.append(f"\n🔹 Job #{i + 1}")
+            result_lines.append(f"   Job ID: {job_id}")
+            result_lines.append(f"   Project: {project}")
+            result_lines.append(f"   Nodes: {nodes}")
+            result_lines.append(f"   Queue: {queue}")
+            result_lines.append(f"   Start Time: {start_time}")
+
+        if len(running_jobs) > limit:
+            result_lines.append(
+                f"\n... and {len(running_jobs) - limit} more running jobs"
+            )
+
+        return "\n".join(result_lines)
+
+    except Exception as e:
+        return f"❌ Error retrieving running jobs: {str(e)}"
+
+
+async def _get_system_health_summary() -> str:
+    """Return a formatted health summary."""
+    try:
+        data = await _fetch_activity_data()
+        running_jobs = data.get("running", [])
+        starting_jobs = data.get("starting", [])
+        queued_jobs = data.get("queued", [])
+
+        total_jobs = len(running_jobs) + len(queued_jobs) + len(starting_jobs)
+
+        if total_jobs == 0:
+            return "⚠️  System Health: Unable to determine - No job data available"
+
+        # Determine health status
+        if len(running_jobs) > 0:
+            health_status = "HEALTHY"
+            emoji = "💚"
+        elif len(queued_jobs) > 0:
+            health_status = "IDLE"
+            emoji = "💛"
+        else:
+            health_status = "INACTIVE"
+            emoji = "❤️"
+
+        summary_lines = [
+            f"{emoji} ALCF Polaris System Health Summary",
+            "=" * 40,
+            f"Overall Status: {health_status}",
+            f"Timestamp: {datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S UTC')}",
+            "",
+            f"📊 Job Statistics:",
+            f"   • Total Jobs: {total_jobs}",
+            f"   • Running: {len(running_jobs)}",
+            f"   • Queued: {len(queued_jobs)}",
+            "",
+            f"🎯 Jobs running: {(len(running_jobs) / max(total_jobs, 1)) * 100:.1f}%",
+        ]
+
+        # Add recommendations
+        if len(running_jobs) == 0 and len(queued_jobs) > 0:
+            summary_lines.append(
+                "\n💡 Note: Jobs are queued but none are running. System may be in maintenance or experiencing issues."
+            )
+        elif len(running_jobs) == 0 and len(queued_jobs) == 0:
+            summary_lines.append(
+                "\n💡 Note: No active job activity detected. System may be offline or in maintenance."
+            )
+
+        return "\n".join(summary_lines)
+
+    except Exception as e:
+        return f"❌ Error generating health summary: {str(e)}"
+
+
+@mcp.resource(uri="alcf://polaris/status")
+async def get_status_resource() -> str:
+    return json.dumps(await _get_system_status(), indent=2)
+
+
+@mcp.resource(uri="alcf://polaris/status/summary")
+async def get_status_summary_resource() -> str:
+    return await _check_alcf_status(False)
+
+
+@mcp.resource(uri="alcf://polaris/jobs")
+async def get_jobs_resource() -> str:
+    return json.dumps(await _get_job_activity(), indent=2)
+
+
+@mcp.resource(uri="alcf://polaris/jobs/summary")
+async def get_jobs_summary_resource() -> str:
+    return await _get_running_jobs(10)
+
+
+@mcp.resource(uri="alcf://polaris/status/health")
+async def get_health_resource() -> str:
+    return await _get_system_health_summary()
+
+
+@mcp.tool
+async def check_alcf_status_json(ctx: Context) -> str:
+    uri = "alcf://polaris/status"
+    await ctx.info(f"Fetching status JSON from {uri}")
+    res = await ctx.read_resource(uri)
+    return res
+
+
+@mcp.tool
+async def check_alcf_status(ctx: Context) -> str:
+    uri = "alcf://polaris/status/summary"
+    await ctx.info(f"Fetching status summary from {uri}")
+    res = await ctx.read_resource(uri)
+    return res
+
+
+@mcp.tool
+async def get_running_jobs_json(ctx: Context) -> str:
+    uri = "alcf://polaris/jobs"
+    await ctx.info(f"Fetching job activity JSON from {uri}")
+    res = await ctx.read_resource(uri)
+    return res
+
+
+@mcp.tool
+async def get_running_jobs(ctx: Context) -> str:
+    uri = "alcf://polaris/jobs/summary"
+    await ctx.info(f"Fetching job activity summary from {uri}")
+    res = await ctx.read_resource(uri)
+    return res
+
+
+@mcp.tool
+async def system_health_summary(ctx: Context) -> str:
+    uri = "alcf://polaris/status/health"
+    await ctx.info(f"Fetching health summary from {uri}")
+    res = await ctx.read_resource(uri)
+    return res
+
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    mcp.run(
+        transport="streamable-http", host="0.0.0.0", port=8000, path="/mcps/alcf-status"
+    )

--- a/mcps/compute-facilities/entrypoint.sh
+++ b/mcps/compute-facilities/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -e
+
+# SERVER_NAME must be passed via --env
+if [ -z "$SERVER_NAME" ]; then
+    echo "ERROR: you must set \$SERVER_NAME to e.g. alcf or nersc" >&2
+    exit 1
+fi
+
+SCRIPT_NAME="${SERVER_NAME}_server.py"
+
+exec conda run --no-capture-output -n science-mcps python "$SCRIPT_NAME"

--- a/mcps/compute-facilities/requirements.txt
+++ b/mcps/compute-facilities/requirements.txt
@@ -1,3 +1,2 @@
-mcp
-asyncio
 aiohttp
+fastmcp

--- a/mcps/globus/Dockerfile
+++ b/mcps/globus/Dockerfile
@@ -1,0 +1,17 @@
+FROM continuumio/miniconda3
+
+EXPOSE 8000/tcp
+
+WORKDIR /science-mcps/mcps/globus
+
+COPY mcps/globus/compute_server.py compute_server.py
+COPY mcps/globus/transfer_server.py transfer_server.py
+COPY mcps/globus/requirements.txt requirements.txt
+
+RUN conda create -y -n science-mcps python=3.11 && \
+    conda run -n science-mcps pip install -r requirements.txt
+
+COPY mcps/globus/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["entrypoint.sh"]

--- a/mcps/globus/entrypoint.sh
+++ b/mcps/globus/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -e
+
+# SERVER_NAME must be passed via --env
+if [ -z "$SERVER_NAME" ]; then
+    echo "ERROR: you must set \$SERVER_NAME to e.g. transfer or compute" >&2
+    exit 1
+fi
+
+SCRIPT_NAME="${SERVER_NAME}_server.py"
+
+exec conda run --no-capture-output -n science-mcps python "$SCRIPT_NAME"

--- a/mcps/globus/requirements.txt
+++ b/mcps/globus/requirements.txt
@@ -1,4 +1,3 @@
-mcp
-globus-sdk
-asyncio
+fastmcp
 globus-compute-sdk
+globus-sdk

--- a/mcps/globus/transfer_server.py
+++ b/mcps/globus/transfer_server.py
@@ -1,250 +1,70 @@
-# globus_mcp_server.py
-import asyncio
+"""FastMCP server exposing Globus Transfer functionality via Globus SDK."""
+
 import logging
 import os
-from typing import Any, Optional, Sequence
+from typing import Optional
+
 import globus_sdk
+from fastmcp import FastMCP
 
-from mcp.server.models import InitializationOptions
-import mcp.types as types
-from mcp.server import NotificationOptions, Server
-import mcp.server.stdio
+logger = logging.getLogger(__name__)
+CLIENT_ID = os.getenv("GLOBUS_CLIENT_ID", "ee05bbfa-2a1a-4659-95df-ed8946e3aae6")
 
-# Configure logging
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger("globus-mcp")
+mcp = FastMCP("Globus Transfer Bridge")
 
-# Global variables for Globus clients
+
+# Globals – initialised lazily after auth
 transfer_client: Optional[globus_sdk.TransferClient] = None
 auth_client: Optional[globus_sdk.NativeAppAuthClient] = None
 
-# Get client ID from environment
-CLIENT_ID = os.getenv("GLOBUS_CLIENT_ID", "ee05bbfa-2a1a-4659-95df-ed8946e3aae6")
 
-# Create server instance
-server = Server("globus-mcp")
-
-
-@server.list_tools()
-async def handle_list_tools() -> list[types.Tool]:
-    """List available Globus tools"""
-    return [
-        types.Tool(
-            name="globus_authenticate",
-            description="Authenticate with Globus and get authorization URL",
-            inputSchema={"type": "object", "properties": {}, "required": []},
-        ),
-        types.Tool(
-            name="complete_globus_auth",
-            description="Complete Globus authentication with authorization code",
-            inputSchema={
-                "type": "object",
-                "properties": {
-                    "auth_code": {
-                        "type": "string",
-                        "description": "Authorization code from Globus",
-                    }
-                },
-                "required": ["auth_code"],
-            },
-        ),
-        types.Tool(
-            name="list_endpoints",
-            description="List available Globus endpoints",
-            inputSchema={
-                "type": "object",
-                "properties": {
-                    "filter_name": {
-                        "type": "string",
-                        "description": "Optional filter to search endpoints by name",
-                    }
-                },
-            },
-        ),
-        types.Tool(
-            name="submit_transfer",
-            description="Submit a transfer job between two Globus endpoints",
-            inputSchema={
-                "type": "object",
-                "properties": {
-                    "source_endpoint": {
-                        "type": "string",
-                        "description": "Source endpoint UUID",
-                    },
-                    "dest_endpoint": {
-                        "type": "string",
-                        "description": "Destination endpoint UUID",
-                    },
-                    "source_path": {
-                        "type": "string",
-                        "description": "Source file/directory path",
-                    },
-                    "dest_path": {
-                        "type": "string",
-                        "description": "Destination file/directory path",
-                    },
-                    "label": {
-                        "type": "string",
-                        "description": "Human-readable label for the transfer",
-                    },
-                },
-                "required": [
-                    "source_endpoint",
-                    "dest_endpoint",
-                    "source_path",
-                    "dest_path",
-                ],
-            },
-        ),
-        types.Tool(
-            name="check_transfer_status",
-            description="Check the status of a Globus transfer job",
-            inputSchema={
-                "type": "object",
-                "properties": {
-                    "task_id": {
-                        "type": "string",
-                        "description": "Transfer task ID to check",
-                    }
-                },
-                "required": ["task_id"],
-            },
-        ),
-        types.Tool(
-            name="list_directory",
-            description="List contents of a directory on a Globus endpoint",
-            inputSchema={
-                "type": "object",
-                "properties": {
-                    "endpoint_id": {
-                        "type": "string",
-                        "description": "Endpoint UUID to browse",
-                    },
-                    "path": {
-                        "type": "string",
-                        "description": "Directory path to list (default: /)",
-                    },
-                },
-                "required": ["endpoint_id"],
-            },
-        ),
-    ]
-
-
-@server.call_tool()
-async def handle_call_tool(
-    name: str, arguments: dict[str, Any]
-) -> list[types.TextContent]:
-    """Handle tool calls"""
-
-    if name == "globus_authenticate":
-        return [types.TextContent(type="text", text=await globus_authenticate())]
-    elif name == "complete_globus_auth":
-        return [
-            types.TextContent(
-                type="text", text=await complete_globus_auth(arguments["auth_code"])
-            )
-        ]
-    elif name == "list_endpoints":
-        return [
-            types.TextContent(
-                type="text", text=await list_endpoints(arguments.get("filter_name", ""))
-            )
-        ]
-    elif name == "submit_transfer":
-        return [
-            types.TextContent(
-                type="text",
-                text=await submit_transfer(
-                    arguments["source_endpoint"],
-                    arguments["dest_endpoint"],
-                    arguments["source_path"],
-                    arguments["dest_path"],
-                    arguments.get("label", "MCP Transfer"),
-                ),
-            )
-        ]
-    elif name == "check_transfer_status":
-        return [
-            types.TextContent(
-                type="text", text=await check_transfer_status(arguments["task_id"])
-            )
-        ]
-    elif name == "list_directory":
-        return [
-            types.TextContent(
-                type="text",
-                text=await list_directory(
-                    arguments["endpoint_id"], arguments.get("path", "/")
-                ),
-            )
-        ]
-    else:
-        raise ValueError(f"Unknown tool: {name}")
-
-
+@mcp.tool
 async def globus_authenticate() -> str:
-    """Authenticate with Globus and get authorization URL"""
+    """Authenticate with Globus and get authorization URL."""
     global auth_client
 
-    if CLIENT_ID == "YOUR_GLOBUS_CLIENT_ID":
-        return "❌ Please set your GLOBUS_CLIENT_ID environment variable."
+    if not CLIENT_ID.lower():
+        return "❌ Please set the GLOBUS_CLIENT_ID environment variable."
 
     try:
-        # Initialize the auth client
         auth_client = globus_sdk.NativeAppAuthClient(CLIENT_ID)
-
-        # Request authorization
         auth_client.oauth2_start_flow(
             requested_scopes=["urn:globus:auth:scope:transfer.api.globus.org:all"]
         )
-
-        # Get the authorization URL
         authorize_url = auth_client.oauth2_get_authorize_url()
-
-        return f"""
-🔐 **Globus Authentication Required**
-
-Please visit this URL to authorize the application:
-
-{authorize_url}
-
-After authorization, you'll get an authorization code. 
-Use the complete_globus_auth tool with that code to finish setup.
-        """.strip()
+        return (
+            "🔗 **Authorization URL**\n\n"
+            "Visit the link, approve access, then call `complete_globus_auth(<code>)` with the returned code.\n\n "
+            f"{authorize_url}"
+        )
 
     except Exception as e:
         logger.error(f"Authentication error: {e}")
         return f"❌ Authentication failed: {str(e)}"
 
 
+@mcp.tool
 async def complete_globus_auth(auth_code: str) -> str:
     """Complete Globus authentication with the authorization code"""
     global auth_client, transfer_client
-
     if not auth_client:
         return "❌ Please call globus_authenticate first to start the auth flow."
 
     try:
-        # Exchange the auth code for tokens
-        token_response = auth_client.oauth2_exchange_code_for_tokens(auth_code)
-
-        # Get the transfer token
+        token_response = auth_client.oauth2_exchange_code_for_tokens(auth_code.strip())
         transfer_token = token_response.by_resource_server["transfer.api.globus.org"][
             "access_token"
         ]
-
-        # Initialize the transfer client
         authorizer = globus_sdk.AccessTokenAuthorizer(transfer_token)
         transfer_client = globus_sdk.TransferClient(authorizer=authorizer)
 
         return "✅ **Authentication completed successfully!** You can now use all Globus transfer functions."
-
     except Exception as e:
         logger.error(f"Token exchange error: {e}")
         return f"❌ Authentication completion failed: {str(e)}"
 
 
+@mcp.tool
 async def list_endpoints(filter_name: str = "") -> str:
     """List available Globus endpoints"""
     if not transfer_client:
@@ -259,7 +79,7 @@ async def list_endpoints(filter_name: str = "") -> str:
             return "No endpoints found matching your criteria."
 
         result = "📡 **Available Endpoints:**\n\n"
-        for ep in endpoints.data['DATA'][:10]:  # Limit to first 10 results
+        for ep in endpoints.data["DATA"][:10]:  # Limit to first 10 results
             result += f"**{ep['display_name']}**\n"
             result += f"   📋 ID: `{ep['id']}`\n"
             result += f"   👤 Owner: {ep['owner_string']}\n"
@@ -267,7 +87,7 @@ async def list_endpoints(filter_name: str = "") -> str:
             result += f"   🔌 Type: {ep.get('entity_type', 'Unknown')}\n"
             result += "-" * 60 + "\n"
 
-        if len(endpoints.data['DATA']) > 10:
+        if len(endpoints.data["DATA"]) > 10:
             result += f"\n... and {len(endpoints.data['DATA']) - 10} more endpoints. Use filter_name to narrow results."
 
         return result
@@ -277,6 +97,7 @@ async def list_endpoints(filter_name: str = "") -> str:
         return f"❌ Failed to list endpoints: {str(e)}"
 
 
+@mcp.tool
 async def submit_transfer(
     source_endpoint: str,
     dest_endpoint: str,
@@ -305,8 +126,8 @@ async def submit_transfer(
         return f"""
 🚀 **Transfer Submitted Successfully!**
 
-📋 **Task ID:** `{result['task_id']}`
-📊 **Status:** {result['message']}
+📋 **Task ID:** `{result["task_id"]}`
+📊 **Status:** {result["message"]}
 🏷️ **Label:** {label}
 📁 **Source:** `{source_path}` on `{source_endpoint}`
 📁 **Destination:** `{dest_path}` on `{dest_endpoint}`
@@ -319,6 +140,7 @@ Use check_transfer_status with the Task ID to monitor progress.
         return f"❌ Transfer submission failed: {str(e)}"
 
 
+@mcp.tool
 async def check_transfer_status(task_id: str) -> str:
     """Check the status of a Globus transfer job"""
     if not transfer_client:
@@ -339,22 +161,22 @@ async def check_transfer_status(task_id: str) -> str:
         result = f"""
 {status_emoji} **Transfer Status Report**
 
-📋 **Task ID:** `{task['task_id']}`
-📊 **Status:** {task['status']}
-🏷️ **Label:** {task['label']}
-📁 **Files Transferred:** {task.get('files_transferred', 0)}
-📊 **Bytes Transferred:** {task.get('bytes_transferred', 0):,} bytes
-🎯 **Source:** {task.get('source_endpoint_display_name', 'Unknown')}
-🎯 **Destination:** {task.get('destination_endpoint_display_name', 'Unknown')}
-⏰ **Submitted:** {task.get('request_time', 'N/A')}
-⏰ **Completed:** {task.get('completion_time', 'In Progress' if task['status'] == 'ACTIVE' else 'N/A')}
+📋 **Task ID:** `{task["task_id"]}`
+📊 **Status:** {task["status"]}
+🏷️ **Label:** {task["label"]}
+📁 **Files Transferred:** {task.get("files_transferred", 0)}
+📊 **Bytes Transferred:** {task.get("bytes_transferred", 0):,} bytes
+🎯 **Source:** {task.get("source_endpoint_display_name", "Unknown")}
+🎯 **Destination:** {task.get("destination_endpoint_display_name", "Unknown")}
+⏰ **Submitted:** {task.get("request_time", "N/A")}
+⏰ **Completed:** {task.get("completion_time", "In Progress" if task["status"] == "ACTIVE" else "N/A")}
         """.strip()
 
         if task["status"] == "FAILED":
             result += f"\n\n❌ **Error Details:** {task.get('nice_status_details', 'Unknown error')}"
         elif task["status"] == "ACTIVE":
             result += (
-                f"\n\n🔄 **Progress:** Transfer is currently active and processing..."
+                "\n\n🔄 **Progress:** Transfer is currently active and processing..."
             )
 
         return result
@@ -364,6 +186,7 @@ async def check_transfer_status(task_id: str) -> str:
         return f"❌ Failed to check transfer status: {str(e)}"
 
 
+@mcp.tool
 async def list_directory(endpoint_id: str, path: str = "/") -> str:
     """List contents of a directory on a Globus endpoint"""
     if not transfer_client:
@@ -381,7 +204,7 @@ async def list_directory(endpoint_id: str, path: str = "/") -> str:
 
         # Sort: directories first, then files
         items = sorted(
-            response.data['DATA'], key=lambda x: (x["type"] != "dir", x["name"].lower())
+            response.data["DATA"], key=lambda x: (x["type"] != "dir", x["name"].lower())
         )
 
         for item in items[:50]:  # Limit to 50 items
@@ -392,7 +215,7 @@ async def list_directory(endpoint_id: str, path: str = "/") -> str:
             )
             result += f"{icon} `{item['name']}`{size}{modified}\n"
 
-        if len(response.data['DATA']) > 50:
+        if len(response.data["DATA"]) > 50:
             result += f"\n... and {len(response.data['DATA']) - 50} more items."
 
         return result
@@ -402,24 +225,11 @@ async def list_directory(endpoint_id: str, path: str = "/") -> str:
         return f"❌ Failed to list directory: {str(e)}"
 
 
-async def main():
-    # Run the server using stdin/stdout streams
-    async with mcp.server.stdio.stdio_server() as (read_stream, write_stream):
-        await server.run(
-            read_stream,
-            write_stream,
-            InitializationOptions(
-                server_name="globus-mcp",
-                server_version="0.2.0",
-                capabilities=server.get_capabilities(
-                    notification_options=NotificationOptions(),
-                    experimental_capabilities={},
-                    # notification=True,
-                    # tools=True,
-                ),
-            ),
-        )
-
-
+# Entrypoint
 if __name__ == "__main__":
-    asyncio.run(main())
+    mcp.run(
+        transport="streamable-http",
+        host="0.0.0.0",
+        port=8000,
+        path="/mcps/globus-transfer",
+    )


### PR DESCRIPTION
# Globus and Compute Endpoint MCPs: FastMCP and Containerization

## Summary
This PR modernizes four MCP servers—Globus Transfer, Globus Compute, NERSC Status, and ALCF Polaris Status—by migrating them to **FastMCP**, standardizing resource URIs, and adding **Docker** support for local testing and Lightsail deployment.

## Globus Servers – What’s Changed
- **FastMCP integration** for both transfer and compute MCPs  
- Consolidated `mcps/globus/requirements.txt` with `fastmcp`, `globus-sdk`, and `globus-compute-sdk`  
- **Containerization**  
  - Single **Dockerfile** and unified **entrypoint.sh** in `mcps/globus/`  
  - `$SERVER_NAME` selects transfer or compute server at runtime  

## Compute Facility Servers – What’s Changed

Kept the original formatting functions (`_check_alcf_status`, `_get_running_jobs`, `_get_system_health_summary`) largely intact, simply exposing their outputs via both resources and tools.

- **NERSC Status**  
  - Migrated to FastMCP  
  - Defined six resource URIs (JSON & summary for all systems, per‐system, availability, maintenance)  
  - Exposed six matching tools that call `ctx.read_resource()`  
- **ALCF Polaris Status**  
  - Migrated to FastMCP  
  - Renamed resource URIs to match tool names (JSON & summary for status, jobs, health)  
  - Exposed five tools for JSON and human summaries

## Resources & Tools

### Globus Transfer Server (`/mcps/globus-transfer`)
|              | Tool Name               | Tool Description                                               |
|---------------------------|-------------------------|----------------------------------------------------------------|
|   | `globus_authenticate`   | Get Globus OAuth2 authorization URL                           |
|                           | `complete_globus_auth`  | Exchange code for tokens and initialize TransferClient         |
|                           | `list_endpoints`        | Search and list Globus endpoints                              |
|                           | `submit_transfer`       | Submit a file transfer between two endpoints                  |
|                           | `check_transfer_status` | Check the status of a submitted transfer task                 |
|                           | `list_directory`        | List directory contents on a specified endpoint               |

### Globus Compute Server (`/mcps/globus-compute`)
|               | Tool Name                 | Tool Description                                             |
|-----------------------------|---------------------------|--------------------------------------------------------------|
|      | `compute_authenticate`    | Start OAuth2 flow for Globus Compute authorization          |
|                             | `complete_compute_auth`   | Exchange code for tokens and initialize Compute client       |
|                             | `register_function`       | Register a Python function for remote execution             |
|                             | `execute_function`        | Execute a registered function on a compute endpoint         |
|                             | `check_task_status`       | Check the status of a submitted compute task                |
|                             | `get_task_result`         | Retrieve the result of a completed compute task             |
|                             | `list_registered_functions` | List all registered compute functions                    |
|                             | `create_hello_world`      | Convenience tool to register a sample “hello world” function |

### NERSC Status Server (`/mcps/nersc-status`)
| Resource URI                           | Tool Name                       | Tool Description                                           |
|----------------------------------------|---------------------------------|------------------------------------------------------------|
| `nersc://status/systems/json`          | `get_nersc_status_json`     | Fetch raw JSON for all NERSC systems                       |
| `nersc://status/systems/summary`       | `get_nersc_status `          | Fetch a human-readable summary of all systems              |
| `nersc://status/{system}`              | `get_nersc_status_individual_json` | Fetch raw JSON for a named system                      |
| `nersc://status/{system}/summary`      | `get_nersc_status_individual`   | Fetch text summary for a named system                      |
| `nersc://status/{system}/get_availability`  | `check_system_availability`     | Check availability for a named system                      |
| `nersc://status/{system}/get_maintenance`   | `get_maintenance_info`          | Retrieve maintenance info for a named system               |

### ALCF Polaris Status Server (`/mcps/alcf-status`)
| Resource URI                                 | Tool Name                 | Tool Description                                          |
|----------------------------------------------|---------------------------|-----------------------------------------------------------|
| `alcf://polaris/status/json`                 | `check_alcf_status_json` | Fetch raw JSON system status from ALCF Polaris            |
| `alcf://polaris/status/summary`              | `check_alcf_status`      | Fetch a human-readable system status summary              |
| `alcf://polaris/jobs/json`                   | `get_running_jobs_json`   | Fetch raw JSON job activity from ALCF Polaris             |
| `alcf://polaris/jobs/summary`                | `get_running_jobs`        | Fetch a human-readable summary of running jobs            |
| `alcf://polaris/status/health/summary`       | `system_health_summary`      | Fetch an overall system health summary                    |

## Next Steps
- Merge and run CI workflows to deploy all four MCPs on Lightsail  
- Create a `develop.md` guide outlining development, testing, and deployment steps  
- Integrate monitoring and alerting for system health endpoints  

## Testing Locally (without Docker)
```bash
# Globus Transfer
cd mcps/globus && python transfer_server.py
# Globus Compute
python compute_server.py

# NERSC Status
cd mcps/compute-facilities && python nersc_server.py
# ALCF Status
python alcf_server.py
```

## Testing Locally with Docker

1. **Build**

```bash
# Globus
cd /path/to/science-mcps/
docker build --platform=linux/amd64 -t science-mcps-globus-image  -f mcps/globus/Dockerfile .

# Compute facilities
cd /path/to/science-mcps/
docker build --platform=linux/amd64 -t science-mcps-facility-image  -f mcps/compute-facilities/Dockerfile .
```

2. **Run**
```bash
# Transfer
docker run --rm -p 8000:8000 -e SERVER_NAME=transfer science-mcps-globus-image
# Compute
docker run --rm -p 8000:8000 -e SERVER_NAME=compute  science-mcps-globus-image

# ALCF
docker run --rm -p 8000:8000 -e SERVER_NAME=alcf science-mcps-facility-image
# NERSC
docker run --rm -p 8000:8000 -e SERVER_NAME=nersc  science-mcps-facility-image
```

3. **Inspect via MCP Inspector** 
In a separate terminal:

```bash
# Globus, assumes the science-mcps env already activated
cd /path/to/science-mcps/mcps/globus
npx @modelcontextprotocol/inspector
```
  OR 
```bash
# Compute facilities,  assumes the science-mcps env already activated
cd /path/to/science-mcps/mcps/globus
npx @modelcontextprotocol/inspector
```

  Then visit:

```
http://localhost:6274/?MCP_PROXY_AUTH_TOKEN=...
```

* **Transport Type:** Streamable HTTP
* **URL:** `http://0.0.0.0:8000/mcps/globus-transfer` (or `…/globus-compute`,   `…/alcf-status`,  `…/nersc-status`)

## Locally use Claude or other AI agents to test, for example:
```json
    "remote-alcf-status-mcp": {
      "command": "npx",
      "args": [
        "mcp-remote",
        "http://0.0.0.0:8000/mcps/alcf-status",
        "--allow-http"
      ]
    }
```

## Testing the Hosted MCPs

```json
{
  "mcpServers": {
    "remote-globus-transfer-mcp": {
      "command": "npx",
      "args": [
        "mcp-remote",
        "https://science-mcps-transfer.qpp943wkvr7b2.us-east-1.cs.amazonlightsail.com/mcps/globus-transfer/"
      ],
      "env": {
        "GLOBUS_CLIENT_ID": "ee05bbfa-2a1a-4659-95df-ed8946e3aae6"
      }
    },
    "remote-globus-compute-mcp": {
      "command": "npx",
      "args": [
        "mcp-remote",
        "https://science-mcps-compute.qpp943wkvr7b2.us-east-1.cs.amazonlightsail.com/mcps/globus-compute/"
      ],
      "env": {
        "GLOBUS_CLIENT_ID": "ee05bbfa-2a1a-4659-95df-ed8946e3aae6"
      }
    },
    "remote-diaspora-mcp": {
      "command": "npx",
      "args": [
        "mcp-remote",
        "https://science-mcps-diaspora.qpp943wkvr7b2.us-east-1.cs.amazonlightsail.com/mcps/diaspora/"
      ],
      "env": {
        "GLOBUS_CLIENT_ID": "ee05bbfa-2a1a-4659-95df-ed8946e3aae6"
      }
    },
    "remote-alcf-status-mcp": {
      "command": "npx",
      "args": [
        "mcp-remote",
        "https://science-mcps-alcf.qpp943wkvr7b2.us-east-1.cs.amazonlightsail.com/mcps/alcf-status/"
      ]
    },
    "remote-nersc-status-mcp": {
      "command": "npx",
      "args": [
        "mcp-remote",
        "https://science-mcps-nersc.qpp943wkvr7b2.us-east-1.cs.amazonlightsail.com/mcps/nersc-status/"
      ]
    }
  }
}
```