### PR TITLE
Update Diaspora MCP

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,8 +1,6 @@
 name: Deploy MCP Servers to AWS Lightsail
 
 on:
-  push:
-    branches: [ main ]
   workflow_dispatch:
 
 jobs:

--- a/mcps/diaspora/Dockerfile
+++ b/mcps/diaspora/Dockerfile
@@ -10,4 +10,7 @@ COPY mcps/diaspora/requirements.txt requirements.txt
 RUN conda create -y -n science-mcps python=3.11 && \
     conda run -n science-mcps pip install -r requirements.txt
 
-ENTRYPOINT ["conda", "run", "--no-capture-output", "-n", "science-mcps", "python", "diaspora_server.py"]
+COPY mcps/diaspora/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["entrypoint.sh"]

--- a/mcps/diaspora/README.md
+++ b/mcps/diaspora/README.md
@@ -4,12 +4,11 @@ A lightweight [FastMCP](https://gofastmcp.com) server that lets Claude (or any M
 
 ## Available Tools
 
-| Category | Tools |
-|----------|-------|
-| **Auth** | `start_diaspora_login`, `finish_diaspora_login`, `logout` |
-| **Credentials** | `create_key` |
-| **Topics** | `list_topics`, `register_topic`, `unregister_topic` |
-| **Data plane** | `publish_event`, `consume_latest_event` |
+| Category       | Tools                                                                                   |
+| -------------- | --------------------------------------------------------------------------------------- |
+| **Auth**       | `start_diaspora_login`, `finish_diaspora_login`, `diaspora_confidential_auth`, `logout` |
+| **Topics**     | `list_topics`, `register_topic`, `unregister_topic`                                     |
+| **Data plane** | `produce_one`, `consume_latest`                                                         |
 
 
 ## Prerequisites
@@ -70,22 +69,21 @@ Register a Diaspora topic, produce three messages, and consume the latest messag
 
 Claude’s typical workflow:
 1. Authenticate with Globus (diaspora_authenticate → complete_diaspora_auth)
-2. Create MSK credentials (create_key)
 3. Register the topic (register_topic)
-4. Publish three UTF-8 messages (publish_event)
-5. Fetch the newest record (consume_latest_event) and display it
+4. Produce three string messages (produce_one)
+5. Consume the newest message (consume_latest) and display it
 
 
 ## Available Tools
 
 * `diaspora_authenticate`	Start the Globus Native-App login flow
 * `complete_diaspora_auth`	Exchange the auth code for refresh tokens
+* `diaspora_confidential_auth` Authenticate via the Globus Client Credentials.
 * `logout`	Revoke stored tokens and clear cached clients
-* `create_key`	Create or rotate the MSK IAM secret for the current user
 * `list_topics`	List all topics owned by the caller
 * `register_topic`	Create a new Kafka topic under the caller’s namespace
 * `unregister_topic`	Delete an existing topic
-* `publish_event`	Publish a UTF-8 message (optionally with key & headers)
-* `consume_latest_event`	Retrieve the most recent message from a topic
+* `produce_one`	Publish a UTF-8 message (optionally with key)
+* `consume_latest`	Retrieve the most recent message from a topic
 
 These tools cover authentication, credential management, topic administration, and core data-plane operations.

--- a/mcps/diaspora/diaspora_server.py
+++ b/mcps/diaspora/diaspora_server.py
@@ -3,23 +3,56 @@
 import functools
 import logging
 import os
-import uuid
+import sys
+from time import time
 from typing import Any, Callable, Optional
 
 import globus_sdk
+from aws_msk_iam_sasl_signer import MSKAuthTokenProvider
 from diaspora_event_sdk import Client as DiasporaClient
-from diaspora_event_sdk import KafkaConsumer, KafkaProducer
-from diaspora_event_sdk.sdk.login_manager import (
-    DiasporaScopes,
-    LoginManager,
-    tokenstore,
-)
+from diaspora_event_sdk.sdk.login_manager import DiasporaScopes, LoginManager
 from fastmcp import FastMCP
 from globus_sdk import ConfidentialAppAuthClient
 from globus_sdk.scopes import AuthScopes
+from kafka import KafkaConsumer, KafkaProducer
+from kafka.sasl.oauth import AbstractTokenProvider
+
+# Required environment variables for AWS Lightsail and local testing
+REQUIRED_ENV_VARS = [
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_DEFAULT_REGION",
+]
+missing = [var for var in REQUIRED_ENV_VARS if not os.getenv(var)]
+if missing:
+    log = logging.getLogger(__name__)
+    log.error(f"Missing required environment variables: {', '.join(missing)}")
+    sys.exit(1)
+
+# Note: AWS Lightsail does not support IAM role assumption; using access keys allows local testing and deployment on Lightsail.
 
 log = logging.getLogger(__name__)
 CLIENT_ID = os.getenv("GLOBUS_CLIENT_ID", "ee05bbfa-2a1a-4659-95df-ed8946e3aae6")
+AWS_ACCOUNT_ID = os.getenv("AWS_ACCOUNT_ID", "423623835312")
+OCTOPUS_BOOTSTRAP_SERVERS = os.getenv(
+    "OCTOPUS_BOOTSTRAP_SERVERS",
+    (
+        "b-1-public.diaspora.jdqn8o.c18.kafka.us-east-1.amazonaws.com:9198,"
+        "b-2-public.diaspora.jdqn8o.c18.kafka.us-east-1.amazonaws.com:9198"
+    ),
+)
+
+# Warn if optional environment variables are not set and defaults are used
+if "GLOBUS_CLIENT_ID" not in os.environ:
+    log.warning(f"GLOBUS_CLIENT_ID not set; using default CLIENT_ID {CLIENT_ID}.")
+if "AWS_ACCOUNT_ID" not in os.environ:
+    log.warning(
+        f"AWS_ACCOUNT_ID not set; using default AWS_ACCOUNT_ID {AWS_ACCOUNT_ID}."
+    )
+if "OCTOPUS_BOOTSTRAP_SERVERS" not in os.environ:
+    log.warning(
+        f"OCTOPUS_BOOTSTRAP_SERVERS not set; using default bootstrap servers {OCTOPUS_BOOTSTRAP_SERVERS}."
+    )
 
 mcp = FastMCP("Diaspora Octopus Bridge")
 
@@ -27,11 +60,8 @@ mcp = FastMCP("Diaspora Octopus Bridge")
 _auth_client: Optional[globus_sdk.NativeAppAuthClient] = None
 _login_mgr: Optional[LoginManager] = None
 _diaspora: Optional[DiasporaClient] = None
-_producer: Optional[KafkaProducer] = None
 _is_logged_in: bool = False  # set True by complete_diaspora_auth
-_have_rotated_key: bool = False  # set True by create_key
-
-# Helper builders
+_user_id: Optional[str] = None
 
 
 def _get_login_mgr() -> LoginManager:
@@ -49,11 +79,61 @@ def _get_diaspora() -> DiasporaClient:
     return _diaspora
 
 
-def _get_producer() -> KafkaProducer:
-    global _producer
-    if _producer is None:
-        _producer = KafkaProducer()
-    return _producer
+class MSKTokenProviderFromRole(AbstractTokenProvider):
+    """MSKTokenProviderFromRole."""
+
+    def __init__(self, open_id: str) -> None:  # pragma: no cover
+        """MSKTokenProviderFromRole init."""
+        self.open_id = open_id
+
+    def token(self) -> str:
+        """MSKTokenProviderFromRole token."""
+        token, _ = MSKAuthTokenProvider.generate_auth_token_from_role_arn(
+            "us-east-1",
+            f"arn:aws:iam::{AWS_ACCOUNT_ID}:role/ap/{self.open_id}-role",
+        )
+        return token
+
+
+def create_producer(
+    open_id: str,
+) -> KafkaProducer:
+    """Create a Kafka producer with the user identity.
+
+    Note: the call should succeed even the user does not exist.
+    """
+    conf = {
+        "bootstrap_servers": OCTOPUS_BOOTSTRAP_SERVERS,
+        "security_protocol": "SASL_SSL",
+        "sasl_mechanism": "OAUTHBEARER",
+        "sasl_oauth_token_provider": MSKTokenProviderFromRole(open_id),
+        "request_timeout_ms": 10000,
+    }
+    producer = KafkaProducer(**conf)
+    return producer
+
+
+def create_consumer(
+    open_id: str,
+    topic: str,
+) -> KafkaConsumer:
+    """Create a Kafka consumer with the user identity and requested topic.
+
+    Note: the call should succeed even if the user does not exist or does not
+      have access to the topic.
+
+    """
+    conf = {
+        "bootstrap_servers": OCTOPUS_BOOTSTRAP_SERVERS,
+        "security_protocol": "SASL_SSL",
+        "sasl_mechanism": "OAUTHBEARER",
+        "sasl_oauth_token_provider": MSKTokenProviderFromRole(open_id),
+        "request_timeout_ms": 10000,
+    }
+
+    consumer = KafkaConsumer(**conf)
+    consumer.subscribe([topic])
+    return consumer
 
 
 def require_login(func: Callable[..., Any]) -> Callable[..., Any]:
@@ -70,26 +150,17 @@ def require_login(func: Callable[..., Any]) -> Callable[..., Any]:
     return wrapper
 
 
-def require_rotated_key(func: Callable[..., Any]) -> Callable[..., Any]:
-    """Ensure the caller has run create_key() at least once."""
-
-    @functools.wraps(func)
-    def wrapper(*args: Any, **kwargs: Any) -> Any:
-        if not _have_rotated_key:
-            raise RuntimeError(
-                "Call create_key once before producing/consuming messages"
-            )
-        return func(*args, **kwargs)
-
-    return wrapper
-
-
-# Globus Native-App login flow tools
-
-
 @mcp.tool
 def diaspora_authenticate() -> str:
-    """Start the Globus Native App flow and return the authorize URL."""
+    """Begin the Globus Native App OAuth2 flow.
+
+    Initiates a Native App login flow for the Diaspora scopes and
+    returns the URL the user must visit to grant access.
+
+    Returns:
+        An authorization URL string. The user should visit this URL,
+        approve access, and then call `complete_diaspora_auth(code)`.
+    """
     global _auth_client
 
     if not CLIENT_ID.lower():
@@ -109,35 +180,20 @@ def diaspora_authenticate() -> str:
 
 
 @mcp.tool
-def diaspora_confidential_auth(
-    client_id: str,
-    client_secret: str,
-) -> str:
-    """Authenticate using the OAuth2 Client Credentials flow."""
-    global _login_mgr, _login_mgr, _diaspora, _is_logged_in
-
-    if not client_id:
-        return "❌ Please provide a confidential client id."
-    if not client_secret:
-        return "❌ Please provide a confidential client secret."
-    ca = ConfidentialAppAuthClient(client_id, client_secret)
-    token_response = ca.oauth2_client_credentials_tokens(
-        requested_scopes=[DiasporaScopes.all, AuthScopes.openid],
-    )
-    storage = tokenstore.get_token_storage_adapter()
-    storage.store(token_response)
-    ca.userinfo = lambda: {"sub": CLIENT_ID}
-    _login_mgr = LoginManager()
-    _login_mgr._auth_client = ca
-    _diaspora = None  # force re-init with our patched client
-    _is_logged_in = True
-    return f"✅ Confidential client authentication successful! {token_response}"
-
-
-@mcp.tool
 def complete_diaspora_auth(code: str) -> str:
-    """Exchange the authorization *code* for tokens and cache them."""
+    """Exchange an OAuth2 authorization code for tokens.
+
+    Args:
+        code: The one-time authorization code returned by the
+              Native App flow.
+
+    Returns:
+        A success message including the user's OpenID on success,
+        or an error string if the exchange fails or wasn't initiated.
+    """
+
     global _auth_client, _login_mgr, _diaspora, _is_logged_in
+    global _user_id
 
     if _auth_client is None:
         return "❌ You must call diaspora_authenticate first."
@@ -149,120 +205,183 @@ def complete_diaspora_auth(code: str) -> str:
         return f"❌ Token exchange failed: {exc}"
 
     _get_login_mgr()._token_storage.store(tokens)
+    userinfo = _get_login_mgr().get_auth_client().userinfo()
+    _user_id = userinfo.get("sub")
+
     _auth_client = None
-    _diaspora = None  # force rebuild
+    _diaspora = None
     _is_logged_in = True
-    return "✅ Login successful! You can now use Diaspora tools."
+    return f"✅ Login successful as user {_user_id}! You can now use Diaspora tools."
+
+
+@mcp.tool
+def diaspora_confidential_auth(
+    client_id: str,
+    client_secret: str,
+) -> str:
+    """Authenticate via the OAuth2 Client Credentials grant.
+
+    Args:
+        client_id: OAuth2 Confidential Client ID.
+        client_secret: OAuth2 Confidential Client Secret.
+
+    Returns:
+        A success message including the service account's OpenID on
+        success, or an error string if credentials are missing.
+    """
+    global _auth_client, _login_mgr, _diaspora, _is_logged_in
+    global _user_id
+
+    if not client_id:
+        return "❌ Please provide a confidential client id."
+    if not client_secret:
+        return "❌ Please provide a confidential client secret."
+    ca = ConfidentialAppAuthClient(client_id, client_secret)
+    tokens = ca.oauth2_client_credentials_tokens(
+        requested_scopes=[DiasporaScopes.all, AuthScopes.openid],
+    )
+
+    _get_login_mgr()._token_storage.store(tokens)
+    userinfo = _get_login_mgr().get_auth_client().userinfo()
+    _user_id = userinfo.get("sub")
+
+    _auth_client = None
+    _diaspora = None
+    _is_logged_in = True
+    return f"✅ Confidential client authentication successful with user {_user_id}!"
 
 
 @mcp.tool
 def logout() -> str:
     """Revoke tokens and clear cached clients."""
-    global _diaspora, _login_mgr, _is_logged_in, _have_rotated_key
+    global _auth_client, _login_mgr, _diaspora, _is_logged_in
+    global _user_id
+
+    # Attempt to revoke tokens via the login manager, if present
+    if _login_mgr:
+        try:
+            logged_out = _login_mgr.logout()
+        except Exception:
+            logged_out = False
+        _login_mgr = None
+    else:
+        logged_out = False
+
+    # Clear all authentication state
+    _auth_client = None
+    _diaspora = None
     _is_logged_in = False
-    _have_rotated_key = False
+    _user_id = None
 
-    if _login_mgr and _login_mgr.logout():
-        _diaspora = None
-        return "🚪 Logged out and tokens revoked."
-    return "ℹ️ No active tokens found."
-
-
-# Control‑plane tools
-
-
-@mcp.tool
-@require_login
-def create_key() -> str:
-    global _have_rotated_key
-    result = _get_diaspora().create_key()
-    _have_rotated_key = True
-    return result
+    # Return appropriate message
+    return (
+        "🚪 Logged out and tokens revoked."
+        if logged_out
+        else "ℹ️ No active tokens found."
+    )
 
 
 @mcp.tool
 @require_login
 def list_topics() -> list[str]:
+    """List all Diaspora event topics the authenticated user can produce and consume."""
     return _get_diaspora().list_topics()
 
 
 @mcp.tool
 @require_login
 def register_topic(topic: str) -> str:
+    """Register a new Diaspora event topic so the user can produce and consume."""
     return _get_diaspora().register_topic(topic)
 
 
 @mcp.tool
 @require_login
 def unregister_topic(topic: str) -> str:
+    """Unregister (delete) an existing Diaspora event topic that the user has registered."""
     return _get_diaspora().unregister_topic(topic)
 
 
-# Data‑plane tools
-
-
 @mcp.tool
 @require_login
-@require_rotated_key
-def produce_event(
+def produce_one(
     topic: str,
     value: str,
     key: str | None = None,
-    headers: dict[str, str] | None = None,
     sync: bool = True,
-) -> str:
-    producer = _get_producer()
-    future = producer.send(topic, value=value, key=key, headers=headers)
-    if sync:
-        md = future.get(timeout=10)
-        return f"partition={md.partition}, offset={md.offset}"
-    return "queued"
+) -> dict[str, Any]:
+    """Produce a single message to a topic that the user has registered."""
+    assert _user_id
+    producer = create_producer(_user_id)
+
+    try:
+        future = producer.send(
+            topic,
+            key=key.encode("utf-8") if key else None,
+            value=value.encode("utf-8"),
+        )
+        if sync:
+            md = future.get(timeout=20)
+            result = {
+                "status": "produced",
+                "topic": md.topic,
+                "partition": md.partition,
+                "offset": md.offset,
+                "timestamp": md.timestamp,
+            }
+
+        else:
+            result = {
+                "status": "queued",
+                "timestamp": int(time() * 1000),
+            }
+        return result
+
+    finally:
+        producer.close()
 
 
 @mcp.tool
 @require_login
-@require_rotated_key
-def consume_latest_event(
-    topic: str,
-    timeout_s: int = 5,
-) -> dict[str, Any] | None:
-    consumer = KafkaConsumer(
-        topic,
-        group_id=f"peek-{uuid.uuid4()}",
-        enable_auto_commit=False,
-        auto_offset_reset="latest",
-        consumer_timeout_ms=timeout_s * 1000,
-    )
+def consume_latest(topic: str, timeout_s: int = 5) -> dict[str, Any]:
+    """Fetch the single most-recent message from a topic that the user has registered."""
+    assert _user_id
 
-    while not consumer.assignment():
-        consumer.poll(100)
+    consumer = create_consumer(_user_id, topic)
+    try:
+        max_attempts, attempts = 10, 0
+        while not consumer.assignment() and attempts < max_attempts:
+            consumer.poll(100)
+            attempts += 1
 
-    for tp in consumer.assignment():
-        end = consumer.end_offsets([tp])[tp]
-        if end:
-            consumer.seek(tp, end - 1)
+        if not consumer.assignment():
+            raise Exception(
+                "consumer cannot acquire partition assignment; maybe the user has not registered the topic."
+            )
 
-    recs = consumer.poll(timeout_s * 1000)
-    newest = None
-    for msgs in recs.values():
-        for msg in msgs:
-            m = {
-                "topic": msg.topic,
-                "partition": msg.partition,
-                "offset": msg.offset,
-                "key": msg.key.decode() if isinstance(msg.key, bytes) else msg.key,
-                "value": msg.value.decode()
-                if isinstance(msg.value, bytes)
-                else msg.value,
-                "timestamp": msg.timestamp,
-            }
-            if newest is None or m["timestamp"] > newest["timestamp"]:
-                newest = m
-    consumer.close()
-    return newest
+        for tp in consumer.assignment():
+            end = consumer.end_offsets([tp])[tp]
+            if end:
+                consumer.seek(tp, end - 1)
 
+        newest = None
+        for msgs in consumer.poll(timeout_s * 1000).values():
+            for msg in msgs:
+                m = {
+                    "topic": msg.topic,
+                    "partition": msg.partition,
+                    "offset": msg.offset,
+                    "key": msg.key.decode() if msg.key else None,
+                    "value": msg.value.decode(),
+                    "timestamp": msg.timestamp,
+                }
+                if newest is None or m["timestamp"] > newest["timestamp"]:
+                    newest = m
+        return newest if newest is not None else {}
 
-# Entrypoint
+    finally:
+        consumer.close()
+
 
 if __name__ == "__main__":
     mcp.run(

--- a/mcps/diaspora/entrypoint.sh
+++ b/mcps/diaspora/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -e
+
+# SERVER_NAME must be passed via --env
+if [ -z "$SERVER_NAME" ]; then
+    echo "ERROR: you must set \$SERVER_NAME to diaspora" >&2
+    exit 1
+fi
+
+SCRIPT_NAME="${SERVER_NAME}_server.py"
+
+exec conda run --no-capture-output -n science-mcps python "$SCRIPT_NAME"

--- a/mcps/diaspora/requirements.txt
+++ b/mcps/diaspora/requirements.txt
@@ -1,2 +1,3 @@
+aws-msk-iam-sasl-signer-python
 diaspora-event-sdk[kafka-python]
 fastmcp


### PR DESCRIPTION
Update Diaspora MCP to use the user's IAM role rather than creating a pair of IAM keys to authenticate
1. `requirements.txt` now has `aws-msk-iam-sasl-signer-python`
2.  authentication logic around `MSKTokenProviderFromRole`
3. other code logic improvements (e.g., avoid consumer infinite polling)
4. `README` documentation and deployment doc (additional AWS variables needed for Diaspora MCP)
5. updated `Dockefile` and created an `entrypoint.sh` as other MCPs
6. Diaspora MCP test cases 