### PR TITLE
Refactor Globus Compute server

### DIFF
--- a/mcps/globus/README.md
+++ b/mcps/globus/README.md
@@ -60,7 +60,8 @@ Edit the claude_desktop_config.json file at `~/Library/Application\ Support/Clau
       "command": "/path/to/your/env/python",
       "args": ["/path/to/science-mcps/mcps/globus/compute_server.py"],
       "env": {
-        "GLOBUS_CLIENT_ID": "ee05bbfa-2a1a-4659-95df-ed8946e3aae6",
+        "GLOBUS_CLIENT_ID": "...",
+        "GLOBUS_CLIENT_SECRET": "...",
       }
     }
   }
@@ -135,14 +136,9 @@ Claude will help you:
 
 ### Globus Compute Server Tools
 
-- `compute_authenticate` - Start Globus Compute authentication
-- `complete_compute_auth` - Complete authentication with an auth code
 - `register_function` - Register a Python function with Globus Compute
-- `execute_function` - Run a registered function on an endpoint
-- `check_task_status` - Check status of a compute task
-- `get_task_result` - Get results from a completed task
-- `list_registered_functions` - List your registered functions
-- `create_hello_world` - Create a test function
+- `submit_task` - Submit a function execution task to an endpoint
+- `check_task_status` - Retrieve the status and result of a task
 
 ## Troubleshooting
 

--- a/mcps/globus/auth.py
+++ b/mcps/globus/auth.py
@@ -1,0 +1,40 @@
+import os
+
+import globus_sdk
+from fastmcp.exceptions import ClientError
+from fastmcp.server.dependencies import get_http_headers
+
+
+def get_client_creds():
+    client_id = os.getenv("GLOBUS_CLIENT_ID")
+    client_secret = os.getenv("GLOBUS_CLIENT_SECRET")
+    return client_id, client_secret
+
+
+def get_access_token():
+    headers = get_http_headers()
+    auth_header = headers.get("authorization")
+    if not auth_header:
+        raise ClientError("Request is missing the required 'Authorization' header")
+    if not auth_header.startswith("Bearer "):
+        raise ClientError("Authorization header must start with 'Bearer '")
+    return auth_header[7:]
+
+
+def get_authorizer():
+    client_id, client_secret = get_client_creds()
+
+    if client_id and client_secret:
+        auth_client = globus_sdk.ConfidentialAppAuthClient(client_id, client_secret)
+        scopes = globus_sdk.ComputeClient.scopes.all
+        return globus_sdk.ClientCredentialsAuthorizer(auth_client, scopes)
+
+    elif client_id:
+        raise ClientError(
+            "Both GLOBUS_CLIENT_ID and GLOBUS_CLIENT_SECRET must be set to use"
+            " a client identity."
+        )
+
+    else:
+        access_token = get_access_token()
+        return globus_sdk.AccessTokenAuthorizer(access_token)

--- a/mcps/globus/entrypoint.sh
+++ b/mcps/globus/entrypoint.sh
@@ -9,4 +9,4 @@ fi
 
 SCRIPT_NAME="${SERVER_NAME}_server.py"
 
-exec conda run --no-capture-output -n science-mcps python "$SCRIPT_NAME"
+exec conda run --no-capture-output -n science-mcps fastmcp run "$SCRIPT_NAME" --transport http --host 0.0.0.0 --port 8000

--- a/mcps/globus/requirements.txt
+++ b/mcps/globus/requirements.txt
@@ -1,3 +1,2 @@
 fastmcp
 globus-compute-sdk
-globus-sdk


### PR DESCRIPTION
- Launching the server directly now uses the stdio transport protocol, which is standard for local use.
- When hosting locally, server admins can specify the `GLOBUS_CLIENT_ID` and `GLOBUS_CLIENT_SECRET` environment variables for client auth.
- When hosting remotely for multiple users, the client must include an access token in the request's `Authorization` header.
- Consolidated the task status and result tools.
- Enforced JSON and pure text (de)serialization.
- Dropped `list_registered_functions` and `create_hello_world` tools.