### PR TITLE
Add garden server

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ The Diaspora MCP server enable AI assistants to:
 
 [Learn more about the Diaspora MCP Server](mcps/diaspora/README.md)
 
+### Garden MCP Server
+
+The Garden MCP server enable AI assistants to:
+
+- **Discover AI Model Gardens** - Search Garden's registry of domain-specific AI-for-science models.
+- **Run Models** - Run inference on Garden models.
+
+[Learn more about the Garden MCP Server](mcps/garden/README.md)
+
 ## Use hosted MCPs (recommended)
 
 Connecting to our hosted MCP servers is the fastest way to get started—no local installation or maintenance required.

--- a/docs/local-mcps.md
+++ b/docs/local-mcps.md
@@ -29,6 +29,9 @@
 
    # For Diaspora server
    pip install -r mcps/diaspora/requirements.txt
+
+   # For Garden server
+   pip install -r mcps/garden/requirements.txt
    ```
 
 ## Setting up MCP Servers in Claude Desktop

--- a/mcps/garden/README.md
+++ b/mcps/garden/README.md
@@ -1,0 +1,120 @@
+# Garden MCP Server
+
+A lightweight [FastMCP](https://gofastmcp.com) server that lets Claude (or any MCP-aware agent) interact with **Garden AI**—a platform for discovering, publishing, and running scientific computing workflows. The server provides tools for running Garden functions and submitting computational jobs to HPC clusters.
+
+## Available Tools
+
+| Category       | Tools                                                                                   |
+| -------------- | --------------------------------------------------------------------------------------- |
+| **Discovery**  | `get_functions`                                                                         |
+| **Execution**  | `run_function`                                                                          |
+| **HPC Jobs**   | `submit_relaxation_job`, `check_job_status`, `get_job_results`                        |
+
+## Prerequisites
+
+- Python 3.11+
+- Garden AI CLI installed and configured
+- A Globus account
+- Claude Desktop application
+
+## Installation
+
+1. Clone this repository:
+   ```bash
+   git clone https://github.com/globus-labs/science-mcps
+   cd science-mcps/mcps/garden
+   ```
+
+2. Create a conda environment:
+   ```bash
+   conda create -n science-mcps python=3.11
+   conda activate science-mcps
+   ```
+
+3. Install the required dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+4. **Important**: Authenticate with Garden AI before starting the server:
+   ```bash
+   garden-ai login
+   ```
+
+5. Start the MCP server:
+   ```bash
+   python garden-mcp.py
+   ```
+
+## Setting up the MCP Server in Claude Desktop
+
+To add this MCP server to Claude Desktop, edit the claude_desktop_config.json file at `~/Library/Application\ Support/Claude/claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "local-garden-mcp": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "http://0.0.0.0:8000/mcps/garden",
+        "--allow-http"
+      ]
+    }
+  }
+}
+```
+
+Make sure the Garden MCP server is running locally before restarting Claude Desktop.
+
+## Usage
+
+Once the Garden MCP server is configured in Claude Desktop, you can ask Claude to perform Garden AI tasks. The server supports both general Garden function execution and specialized HPC cluster workflows.
+
+### General Garden Workflow
+
+Ask Claude:
+```
+What functions are available in the garden with DOI "10.23677/example-garden"?
+```
+
+Claude's workflow:
+1. Use `get_functions` to discover available functions in the Garden
+2. Optionally use `run_function` to execute specific functions
+
+### HPC Structure Relaxation Workflow
+
+Ask Claude:
+```
+Submit my structures in /path/to/structures.xyz for relaxation using MACE-MP-0, then check the status and save results when complete
+```
+
+Claude's workflow:
+1. Use `submit_relaxation_job` to submit the XYZ file to Edith HPC cluster
+2. Use `check_job_status` to monitor the job progress  
+3. Use `get_job_results` to retrieve and save results when complete
+
+## Available Tools
+
+### Discovery Tools
+* `get_functions(doi)` - List all available function names for a Garden by DOI
+
+### Execution Tools  
+* `run_function(doi, func_name, func_args)` - Execute a specific Garden function with provided arguments
+
+### HPC Cluster Tools
+* `submit_relaxation_job(xyz_file_path, model="mace-mp-0")` - Submit structure relaxation job to Edith HPC cluster using MLIP Garden
+* `check_job_status(job_id)` - Check the status of a submitted relaxation job
+* `get_job_results(job_id, output_file_path=None)` - Retrieve results from completed jobs, optionally saving to file
+
+The HPC tools maintain job context across calls using a persistent MLIP Garden instance, enabling full workflow management from submission through result retrieval.
+
+## Authentication
+
+Before using the server, ensure you're authenticated with Garden AI:
+
+```bash
+garden-ai login
+```
+
+This authentication persists across server restarts and is required for accessing Garden functions and submitting HPC jobs.

--- a/mcps/garden/garden-mcp.py
+++ b/mcps/garden/garden-mcp.py
@@ -1,0 +1,169 @@
+from fastmcp import FastMCP
+from garden_ai.client import GardenClient
+from fastmcp.exceptions import ToolError
+from pathlib import Path
+import json
+
+mcp = FastMCP("Garden MCP Server")
+
+# Global singleton for MLIP Garden to maintain job context across tool calls
+_mlip_garden = None
+
+def get_mlip_garden():
+    """
+    Lazy initialization of MLIP Garden singleton to maintain job context.
+    """
+    global _mlip_garden
+    if _mlip_garden is None:
+        import garden_ai
+        _mlip_garden = garden_ai.get_garden("mlip-garden")
+    return _mlip_garden
+
+
+@mcp.tool
+def get_functions(doi: str):
+    """
+    Return a list of available modal function names for this Garden.
+    """
+    garden = GardenClient().get_garden(doi)
+    data = garden.metadata.model_dump(
+        exclude={"owner_identity_id", "id", "language", "publisher"}
+    )
+    data["entrypoints"] = [ep.metadata.model_dump() for ep in garden.entrypoints]
+    data["modal_functions"] = [
+        mf.metadata.model_dump() for mf in garden.modal_functions
+    ]
+    return [f["function_name"] for f in data["modal_functions"]]
+
+
+@mcp.tool
+def run_function(
+    doi: str,
+    func_name: str,
+    func_args: list[str],
+):
+    """
+    Load the Garden by DOI, locate the named function, and invoke it with the provided args.
+    """
+    garden = GardenClient().get_garden(doi)
+    entrypoint = getattr(garden, func_name, None)
+    if entrypoint is None:
+        raise ToolError(f"No such function '{func_name}' in garden '{doi}'")
+    try:
+        result = entrypoint(func_args)
+    except Exception as e:
+        raise ToolError(f"Error running '{func_name}(...)': {e}")
+    return result
+
+
+@mcp.tool
+def submit_relaxation_job(
+    xyz_file_path: str, 
+    model: str = "mace-mp-0"
+):
+    """
+    Submit an XYZ structure file for relaxation on the Edith HPC cluster using the MLIP Garden.
+    
+    Args:
+        xyz_file_path: Path to the XYZ file containing structures to relax
+        model: The ML interatomic potential model to use (default: "mace-mp-0")
+    
+    Returns:
+        job_id: The job ID for tracking the submitted job
+    """
+    try:
+        xyz_file = Path(xyz_file_path)
+        if not xyz_file.exists():
+            raise ToolError(f"XYZ file not found: {xyz_file_path}")
+        
+        # Edith HPC cluster endpoint ID
+        edith_ep_id = "a01b9350-e57d-4c8e-ad95-b4cb3c4cd1bb"
+        
+        # Use singleton MLIP garden to maintain job context
+        mlip_garden = get_mlip_garden()
+        job_id = mlip_garden.batch_relax(xyz_file, model=model, cluster_id=edith_ep_id)
+        
+        return {
+            "job_id": job_id,
+            "message": f"Successfully submitted relaxation job for {xyz_file_path}",
+            "model": model,
+            "cluster": "Edith"
+        }
+    except Exception as e:
+        raise ToolError(f"Failed to submit relaxation job: {e}")
+
+
+@mcp.tool  
+def check_job_status(job_id: str):
+    """
+    Check the status of a previously submitted relaxation job.
+    
+    Args:
+        job_id: The job ID returned from submit_relaxation_job
+        
+    Returns:
+        Status information for the job
+    """
+    try:
+        # Use singleton MLIP garden to access job context
+        mlip_garden = get_mlip_garden()
+        status = mlip_garden.get_job_status(job_id)
+        
+        return {
+            "job_id": job_id,
+            "status": status,
+            "message": f"Job {job_id} status: {status}"
+        }
+    except Exception as e:
+        raise ToolError(f"Failed to check job status for {job_id}: {e}")
+
+
+@mcp.tool
+def get_job_results(job_id: str, output_file_path: str = None):
+    """
+    Retrieve the results of a completed relaxation job and optionally save to file.
+    
+    Args:
+        job_id: The job ID returned from submit_relaxation_job
+        output_file_path: Optional path to save the results to a file
+        
+    Returns:
+        The job results, and confirmation if saved to file
+    """
+    try:
+        # Use singleton MLIP garden to access job context
+        mlip_garden = get_mlip_garden()
+        results = mlip_garden.get_results(job_id)
+        
+        response = {
+            "job_id": job_id,
+            "results": results
+        }
+        
+        # Optionally save results to file
+        if output_file_path:
+            output_path = Path(output_file_path)
+            
+            # Create parent directories if they don't exist
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            
+            # Save results as JSON
+            with open(output_path, 'w') as f:
+                json.dump(results, f, indent=2, default=str)
+            
+            response["saved_to"] = str(output_path)
+            response["message"] = f"Results retrieved and saved to {output_path}"
+        else:
+            response["message"] = f"Results retrieved for job {job_id}"
+            
+        return response
+        
+    except Exception as e:
+        raise ToolError(f"Failed to get results for job {job_id}: {e}")
+
+
+if __name__ == "__main__":
+    mcp.run(transport="streamable-http", host="0.0.0.0", port=8000, path="/mcps/garden")
+
+# if __name__ == "__main__":
+#     mcp.run(transport="stdio")

--- a/mcps/garden/requirements.txt
+++ b/mcps/garden/requirements.txt
@@ -1,0 +1,3 @@
+garden-ai
+ase
+fastmcp


### PR DESCRIPTION
This PR adds a Garden MCP server that Haochen cooked up and I added some extra tools to. See below for an example usage on Edith at ALCF.

<img width="432" height="899" alt="Screenshot 2025-07-14 at 1 42 09 PM" src="https://github.com/user-attachments/assets/5a2a94c6-7190-484a-9a22-f16f17f02c85" />
