### PR TITLE
Enable secure local auth with GlobusApps

### DIFF
--- a/mcps/globus/README.md
+++ b/mcps/globus/README.md
@@ -58,11 +58,7 @@ Edit the claude_desktop_config.json file at `~/Library/Application\ Support/Clau
   "mcpServers": {
     "globus-compute-mcp": {
       "command": "/path/to/your/env/python",
-      "args": ["/path/to/science-mcps/mcps/globus/compute_server.py"],
-      "env": {
-        "GLOBUS_CLIENT_ID": "...",
-        "GLOBUS_CLIENT_SECRET": "...",
-      }
+      "args": ["/path/to/science-mcps/mcps/globus/compute_server.py"]
     }
   }
 }
@@ -81,10 +77,7 @@ Edit the claude_desktop_config.json file at `~/Library/Application\ Support/Clau
     ...,
     "globus-transfer-mcp": {
       "command": "/path/to/your/env/python",
-      "args": ["/path/to/science-mcps/mcps/globus/transfer_server.py"],
-      "env": {
-        "GLOBUS_CLIENT_ID": "ee05bbfa-2a1a-4659-95df-ed8946e3aae6",
-      }
+      "args": ["/path/to/science-mcps/mcps/globus/transfer_server.py"]
     }
   }
 }

--- a/mcps/globus/auth.py
+++ b/mcps/globus/auth.py
@@ -1,8 +1,10 @@
 import os
+import platform
 
 import globus_sdk
 from fastmcp.exceptions import ClientError
-from fastmcp.server.dependencies import get_http_headers
+
+DEFAULT_CLIENT_ID = "ee05bbfa-2a1a-4659-95df-ed8946e3aae6"
 
 
 def get_client_creds():
@@ -11,29 +13,22 @@ def get_client_creds():
     return client_id, client_secret
 
 
-def get_access_token():
-    headers = get_http_headers()
-    auth_header = headers.get("authorization")
-    if not auth_header:
-        raise ClientError("Request is missing the required 'Authorization' header")
-    if not auth_header.startswith("Bearer "):
-        raise ClientError("Authorization header must start with 'Bearer '")
-    return auth_header[7:]
-
-
-def get_authorizer(scopes: str | list[str]):
+def get_globus_app() -> globus_sdk.GlobusApp:
+    app_name = platform.node()
     client_id, client_secret = get_client_creds()
 
     if client_id and client_secret:
-        auth_client = globus_sdk.ConfidentialAppAuthClient(client_id, client_secret)
-        return globus_sdk.ClientCredentialsAuthorizer(auth_client, scopes)
+        return globus_sdk.ClientApp(
+            app_name=app_name, client_id=client_id, client_secret=client_secret
+        )
 
-    elif client_id:
+    elif client_secret:
         raise ClientError(
-            "Both GLOBUS_CLIENT_ID and GLOBUS_CLIENT_SECRET must be set to use"
-            " a client identity."
+            "Both GLOBUS_CLIENT_ID and GLOBUS_CLIENT_SECRET must be set to"
+            " use a client identity."
         )
 
     else:
-        access_token = get_access_token()
-        return globus_sdk.AccessTokenAuthorizer(access_token)
+        client_id = client_id or DEFAULT_CLIENT_ID
+        config = globus_sdk.GlobusAppConfig(login_flow_manager="local-server")
+        return globus_sdk.UserApp(app_name=app_name, client_id=client_id, config=config)

--- a/mcps/globus/compute_server.py
+++ b/mcps/globus/compute_server.py
@@ -16,7 +16,7 @@ from globus_compute_sdk.serialize import (
 )
 from globus_compute_sdk.serialize.facade import validate_strategylike
 
-from auth import get_authorizer
+from auth import get_globus_app
 from schemas import (
     ComputeFunctionRegisterResponse,
     ComputeSubmitResponse,
@@ -29,13 +29,12 @@ mcp = FastMCP("Globus Compute MCP Server")
 
 
 def get_compute_client():
-    scopes = globus_sdk.ComputeClient.scopes.all
-    authorizer = get_authorizer(scopes)
+    app = get_globus_app()
     serializer = ComputeSerializer(
         # Ensure no dill deserialization on the server
         allowed_deserializer_types=[JSONData, PureSourceTextInspect],
     )
-    return Client(authorizer=authorizer, serializer=serializer, do_version_check=False)
+    return Client(app=app, serializer=serializer, do_version_check=False)
 
 
 def _format_function_payload(

--- a/mcps/globus/requirements.txt
+++ b/mcps/globus/requirements.txt
@@ -1,2 +1,3 @@
 fastmcp
 globus-compute-sdk
+globus-sdk

--- a/mcps/globus/transfer_server.py
+++ b/mcps/globus/transfer_server.py
@@ -6,7 +6,7 @@ from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
 from pydantic import Field
 
-from auth import get_authorizer
+from auth import get_globus_app
 from schemas import (
     TransferEndpoint,
     TransferEvent,
@@ -20,9 +20,8 @@ mcp = FastMCP("Globus Transfer MCP Server")
 
 
 def get_transfer_client():
-    scopes = globus_sdk.TransferClient.scopes.all
-    authorizer = get_authorizer(scopes)
-    return globus_sdk.TransferClient(authorizer=authorizer)
+    app = get_globus_app()
+    return globus_sdk.TransferClient(app=app)
 
 
 def _format_endpoint_search_response(


### PR DESCRIPTION
- When calling a tool that requires authentication with Globus Auth, a customized `UserApp` object will initiate a login flow in the user's web browser, then launch a locally hosted HTTP server for the redirect URI. The local HTTP server will automatically receive the auth code from Globus Auth after consent, ensuring a secure exchange.

- Specifying the `GLOBUS_CLIENT_ID` and `GLOBUS_CLIENT_SECRET` env vars will cause the MCP server to use a `ClientApp` for auth and skip the login flow.

- Dropped support for Authorization header access tokens until we plan to officially support hosted MCP servers.

- Created a function to dynamically initiate a login flow when Globus Auth returns a Globus Auth Requirements Error (GARE) indicating that the user must consent to an additional scope. The motivating use-case is handling Transfer collection-specific dependent `data_access` scopes.